### PR TITLE
simplify build pages flow

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -30,6 +30,7 @@ jobs:
         run: pip install pandas
 
       - name: Build static leaderboard page
+        id: build
         run: python scripts/build_pages.py
 
       - name: Setup Pages
@@ -38,7 +39,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './docs'
+          path: ${{ steps.build.outputs.temp_dir }}
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/matches/2025-08-09-1.yml
+++ b/matches/2025-08-09-1.yml
@@ -1,9 +1,0 @@
-date: '2025-08-09'
-players:
-- alice
-- bob
-sets:
-- - 5
-  - 2
-source_issue: 1
-

--- a/ranking.csv
+++ b/ranking.csv
@@ -1,2 +1,1 @@
 player,rating
-alice,100

--- a/ranking.csv
+++ b/ranking.csv
@@ -1,3 +1,1 @@
 player,rating
-alice,1216.0
-bob,1184.0

--- a/ranking.csv
+++ b/ranking.csv
@@ -1,1 +1,2 @@
 player,rating
+alice,100

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import os
+import tempfile
 from datetime import datetime
 
 
@@ -78,12 +79,26 @@ def build_leaderboard():
     </html>
     """
 
-    # Write the HTML to docs/index.html
-    with open("docs/index.html", "w") as f:
+    # Create a temporary directory and write the HTML
+    temp_dir = tempfile.mkdtemp(prefix="tennis_leaderboard_")
+    output_file = os.path.join(temp_dir, "index.html")
+
+    with open(output_file, "w") as f:
         f.write(html_template)
 
-    print("Leaderboard successfully built at docs/index.html")
+    print(f"Leaderboard successfully built at {output_file}")
+    print(f"Temporary directory: {temp_dir}")
+
+    return temp_dir, output_file
 
 
 if __name__ == "__main__":
-    build_leaderboard()
+    temp_dir, output_file = build_leaderboard()
+
+    # Output for GitHub Actions to capture
+    print(f"TEMP_DIR={temp_dir}")
+
+    # Also write to GitHub Actions environment if running in CI
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        with open(os.environ.get("GITHUB_OUTPUT", "/dev/null"), "a") as f:
+            f.write(f"temp_dir={temp_dir}\n")

--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -5,8 +5,6 @@ from datetime import datetime
 
 
 def get_repo_info():
-    """Extract repository owner and name from environment or git remote."""
-    # Try GitHub Actions environment variables first
     github_repository = os.environ.get("GITHUB_REPOSITORY")
     if github_repository:
         owner, repo = github_repository.split("/")
@@ -86,19 +84,13 @@ def build_leaderboard():
     with open(output_file, "w") as f:
         f.write(html_template)
 
-    print(f"Leaderboard successfully built at {output_file}")
-    print(f"Temporary directory: {temp_dir}")
-
     return temp_dir, output_file
 
 
 if __name__ == "__main__":
     temp_dir, output_file = build_leaderboard()
 
-    # Output for GitHub Actions to capture
-    print(f"TEMP_DIR={temp_dir}")
-
-    # Also write to GitHub Actions environment if running in CI
+    # write to GitHub Actions environment if running in CI so that the pages-deploy.yml can use it
     if os.environ.get("GITHUB_ACTIONS") == "true":
         with open(os.environ.get("GITHUB_OUTPUT", "/dev/null"), "a") as f:
             f.write(f"temp_dir={temp_dir}\n")


### PR DESCRIPTION
I wanted to get rid of the /docs directory. It was used to write the output of our build_page script and then was used to deploy to github pages. The build artifacts from that process do not need to be stored at all. They can be built in the runner and then deployed from the runner. They are completely ephemeral. That is what I have done with this pr