### PR TITLE
fix(ci): Install all dependencies in deploy workflow

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install pandas
+        run: pip install -r requirements.txt
 
       - name: Build static leaderboard page
         id: build


### PR DESCRIPTION
The pages deployment workflow was failing because it was missing the PyYAML and numpy dependencies. This change updates the workflow to install all dependencies from requirements.txt, which will ensure the build environment is correctly configured.