### PR TITLE
fix(ci): Remove newline from build script output

### DIFF
--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -118,4 +118,4 @@ if __name__ == "__main__":
     temp_dir, output_file = build_leaderboard()
     if os.environ.get("GITHUB_ACTIONS") == "true":
         with open(os.environ.get("GITHUB_OUTPUT", "/dev/null"), "a") as f:
-            f.write(f"temp_dir={temp_dir}\\n")
+            f.write(f"temp_dir={temp_dir}")


### PR DESCRIPTION
The build script (scripts/build_pages.py) was adding a newline character to the temp_dir output variable, which caused the deployment workflow to fail. This commit removes the extraneous newline character.