### PR TITLE
prevent score from wrapping on match history field

### DIFF
--- a/scripts/build_history.py
+++ b/scripts/build_history.py
@@ -224,6 +224,7 @@ def build_history_page(output_dir: Optional[str] = None):
                 text-align: center;
             }}
             ul {{ margin-bottom: 0; padding-left: 1.5rem; }}
+            td ul li {{ white-space: nowrap; }}
             .table-responsive {{ 
                 max-height: 600px; 
                 overflow-y: auto; 


### PR DESCRIPTION
Brings up a one-line CSS fix that was committed to the live league (sc-tennis-league) but never made it upstream.

Adds `td ul li { white-space: nowrap; }` to the match-history page styles so set scores don't wrap mid-cell.

Originally authored by Aaron Sykes (commit de967d6 in the downstream repo); cherry-picked here so it lands in the template and flows back down on the next sync.