### PR TITLE
Normalize player handles case-insensitively

### DIFF
--- a/scripts/build_history.py
+++ b/scripts/build_history.py
@@ -7,7 +7,7 @@ import tempfile
 from typing import Optional
 
 from github_utils import get_repo_owner_and_name_or_default, list_issue_comments
-from scripts.elo_utils import update_elo_ratings, update_doubles_elo_ratings, normalize_team
+from scripts.elo_utils import update_elo_ratings, update_doubles_elo_ratings, normalize_team, normalize_player
 
 # Pre-compiled regex for efficiency
 # Matches " #123" in the bot's comment
@@ -53,6 +53,12 @@ def load_matches_from_directory(directory: str, match_type: str, ratings, team_r
         match_path = os.path.join(directory, match_file)
         with open(match_path, "r") as f:
             match_data = yaml.safe_load(f)
+
+        # Canonicalize handles up front so ELO keys and profile links stay
+        # consistent with the rest of the system (case-insensitive identity).
+        for key in ("players", "team1", "team2"):
+            if key in match_data:
+                match_data[key] = [normalize_player(p) for p in match_data[key]]
 
         issue_search = ISSUE_NUM_RE.search(match_file)
         if not issue_search:

--- a/scripts/build_player_pages.py
+++ b/scripts/build_player_pages.py
@@ -10,6 +10,7 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from github_utils import get_repo_owner_and_name_or_default
+from scripts.elo_utils import normalize_player
 
 K = 32
 PLAYER_DATA = {} # {player: {singles: {candlestick: [], scatter: []}, doubles: {candlestick: [], scatter: []}}}
@@ -72,7 +73,7 @@ def calculate_elo_history():
                     daily_elo_changes[p] = {'singles': {'elos': [], 'details': []}, 'doubles': {'elos': [], 'details': []}}
 
             if 'players' in match_data: # Singles match
-                player1, player2 = match_data['players']
+                player1, player2 = (normalize_player(p) for p in match_data['players'])
                 ensure_player_data(player1)
                 ensure_player_data(player2)
 
@@ -106,8 +107,8 @@ def calculate_elo_history():
                     daily_elo_changes[loser]['singles']['details'].append(loser_details)
 
             elif 'team1' in match_data: # Doubles match
-                team1 = match_data['team1']
-                team2 = match_data['team2']
+                team1 = [normalize_player(p) for p in match_data['team1']]
+                team2 = [normalize_player(p) for p in match_data['team2']]
                 all_players = team1 + team2
                 for p in all_players:
                     ensure_player_data(p)

--- a/scripts/elo_utils.py
+++ b/scripts/elo_utils.py
@@ -4,6 +4,16 @@ This module provides shared ELO rating calculation functions.
 
 K = 32
 
+def normalize_player(name):
+    """Canonicalize a player handle for case-insensitive identity.
+
+    GitHub usernames are unique and case-insensitive, so "Johnor12" and
+    "johnor12" are the same account. Lowercasing collapses casing variants
+    to a single player so stats and profile pages don't split. Also strips
+    surrounding whitespace and a leading '@'.
+    """
+    return name.strip().lstrip("@").lower()
+
 def expected(rA, rB):
     """
     Calculate the expected score of player A in a match against player B.

--- a/scripts/generate_doubles_ranking.py
+++ b/scripts/generate_doubles_ranking.py
@@ -2,7 +2,7 @@ import glob
 import sys
 import yaml
 import pandas as pd
-from scripts.elo_utils import update_doubles_elo_ratings, normalize_team
+from scripts.elo_utils import update_doubles_elo_ratings, normalize_team, normalize_player
 
 # --- Team-based data ---
 team_ratings = {}
@@ -35,8 +35,8 @@ def _ensure_player_stats(player: str) -> None:
 
 def apply_match(match):
     """Update ratings and aggregates from a single doubles match file."""
-    team1_players = match["team1"]
-    team2_players = match["team2"]
+    team1_players = [normalize_player(p) for p in match["team1"]]
+    team2_players = [normalize_player(p) for p in match["team2"]]
 
     # Normalize team names for team-based stats
     team1_key = normalize_team(team1_players)

--- a/scripts/generate_singles_ranking.py
+++ b/scripts/generate_singles_ranking.py
@@ -2,7 +2,7 @@ import glob
 import sys
 import yaml
 import pandas as pd
-from scripts.elo_utils import update_elo_ratings
+from scripts.elo_utils import normalize_player, update_elo_ratings
 
 ratings = {}
 elo_changes = []
@@ -29,7 +29,8 @@ def apply_match(match):
     Elo is applied per set. Each set is an independent event that updates
     the players' ratings based solely on who won the set (score margin ignored).
     """
-    player1, player2 = match["players"]
+    player1 = normalize_player(match["players"][0])
+    player2 = normalize_player(match["players"][1])
 
     # Ensure player entries exist for aggregation
     _ensure_player(player1)

--- a/scripts/parse_doubles_issue.py
+++ b/scripts/parse_doubles_issue.py
@@ -20,8 +20,8 @@ def parse_issue_body(body):
         teams_str = teams_match.group(1).strip()
         if "||" in teams_str:
             team1_str, team2_str = teams_str.split("||")
-            team1_players = [p.strip().replace("@", "") for p in team1_str.split(",")]
-            team2_players = [p.strip().replace("@", "") for p in team2_str.split(",")]
+            team1_players = [p.strip().replace("@", "").lower() for p in team1_str.split(",")]
+            team2_players = [p.strip().replace("@", "").lower() for p in team2_str.split(",")]
             details["team1"] = team1_players
             details["team2"] = team2_players
             # Flatten for individual player access

--- a/scripts/parse_singles_issue.py
+++ b/scripts/parse_singles_issue.py
@@ -18,7 +18,7 @@ def parse_issue_body(body):
     players_match = re.search(r"### Players.*?\n\s*([^\n]+)", body)
     if players_match:
         players_str = players_match.group(1).strip()
-        details["players"] = [p.strip().replace("@", "") for p in players_str.split(",")]
+        details["players"] = [p.strip().replace("@", "").lower() for p in players_str.split(",")]
 
     sets_match = re.search(r"### Sets.*?\n(.*?)(?=\n###|\Z)", body, re.DOTALL)
     if sets_match:

--- a/tests/test_casing.py
+++ b/tests/test_casing.py
@@ -1,0 +1,96 @@
+"""Tests for case-insensitive player handle normalization.
+
+GitHub usernames are unique and case-insensitive, so "Johnor12" and
+"johnor12" must resolve to one player. These cover the shared helper and
+its effect through the parsers and ranking aggregation.
+"""
+
+import pytest
+
+import scripts.generate_doubles_ranking as doubles
+import scripts.generate_singles_ranking as singles
+from scripts.elo_utils import normalize_player
+from scripts.parse_doubles_issue import parse_issue_body as parse_doubles
+from scripts.parse_singles_issue import parse_issue_body as parse_singles
+
+
+@pytest.fixture(autouse=True)
+def reset_module_state():
+    singles.ratings.clear()
+    singles.stats.clear()
+    singles.elo_changes.clear()
+    doubles.team_ratings.clear()
+    doubles.team_stats.clear()
+    doubles.individual_ratings.clear()
+    doubles.individual_stats.clear()
+    yield
+
+
+# --- normalize_player ------------------------------------------------------
+
+
+def test_normalize_lowercases():
+    assert normalize_player("Johnor12") == "johnor12"
+
+
+def test_normalize_strips_whitespace_and_at_sign():
+    assert normalize_player("  @HunterJSB ") == "hunterjsb"
+
+
+def test_normalize_is_idempotent():
+    assert normalize_player(normalize_player("MixedCase")) == "mixedcase"
+
+
+def test_normalize_already_canonical_unchanged():
+    assert normalize_player("jeffson66") == "jeffson66"
+
+
+# --- parsers store canonical handles --------------------------------------
+
+
+def test_singles_parser_lowercases_handles():
+    body = """### Match date (YYYY-MM-DD)
+2026-01-01
+### Players
+@HunterJSB, @Johnor12
+### Sets
+6-3
+"""
+    assert parse_singles(body)["players"] == ["hunterjsb", "johnor12"]
+
+
+def test_doubles_parser_lowercases_handles():
+    body = """### Match date (YYYY-MM-DD)
+2026-01-01
+### Teams
+@Alice, @Bob || @Carol, @Dave
+### Sets
+6-3
+"""
+    parsed = parse_doubles(body)
+    assert parsed["team1"] == ["alice", "bob"]
+    assert parsed["team2"] == ["carol", "dave"]
+
+
+# --- aggregation dedupes across casing ------------------------------------
+
+
+def test_singles_mixed_casing_aggregates_to_one_player():
+    # Same player entered two ways across two matches must not split.
+    singles.apply_match({"players": ["HunterJSB", "bob"], "sets": [[6, 3]]})
+    singles.apply_match({"players": ["hunterjsb", "carol"], "sets": [[6, 4]]})
+    assert "HunterJSB" not in singles.stats
+    assert singles.stats["hunterjsb"]["set_wins"] == 2
+
+
+def test_doubles_mixed_casing_aggregates_to_one_team_and_player():
+    doubles.apply_match(
+        {"team1": ["Alice", "Bob"], "team2": ["c", "d"], "sets": [[6, 3]]}
+    )
+    doubles.apply_match(
+        {"team1": ["alice", "bob"], "team2": ["e", "f"], "sets": [[6, 4]]}
+    )
+    # One canonical team key and one canonical player entry.
+    assert "alice, bob" in doubles.team_ratings
+    assert doubles.team_stats["alice, bob"]["set_wins"] == 2
+    assert doubles.individual_stats["alice"]["set_wins"] == 2

--- a/tests/test_casing.py
+++ b/tests/test_casing.py
@@ -9,6 +9,7 @@ import pytest
 
 import scripts.generate_doubles_ranking as doubles
 import scripts.generate_singles_ranking as singles
+from scripts.build_history import load_matches_from_directory
 from scripts.elo_utils import normalize_player
 from scripts.parse_doubles_issue import parse_issue_body as parse_doubles
 from scripts.parse_singles_issue import parse_issue_body as parse_singles
@@ -94,3 +95,21 @@ def test_doubles_mixed_casing_aggregates_to_one_team_and_player():
     assert "alice, bob" in doubles.team_ratings
     assert doubles.team_stats["alice, bob"]["set_wins"] == 2
     assert doubles.individual_stats["alice"]["set_wins"] == 2
+
+
+# --- match history page links match the (lowercase) profile pages ----------
+
+
+def test_history_profile_links_are_normalized(tmp_path):
+    # A match recorded with a capital handle must link to the lowercase
+    # profile page that build_player_pages actually generates.
+    (tmp_path / "2026-01-01-1.yml").write_text(
+        "date: '2026-01-01'\n"
+        "players:\n- HunterJSB\n- Johnor12\n"
+        "sets:\n- - 6\n  - 3\nsource_issue: 1\n"
+    )
+    matches = load_matches_from_directory(str(tmp_path), "singles", {})
+    display = matches[0]["players_display"]
+    assert "player_profile_hunterjsb.html" in display
+    assert "player_profile_johnor12.html" in display
+    assert "Johnor12" not in display and "HunterJSB" not in display


### PR DESCRIPTION
## What

GitHub usernames are unique and **case-insensitive** — `@Johnor12` and `@johnor12` are the same account. The ranking engine keyed players by the exact string, so a casing variant would silently split a player's stats and generate a second profile page.

Adds `normalize_player()` (lowercase + strip whitespace/`@`) in `scripts/elo_utils.py` and applies it:
- **Parse time** — `parse_singles_issue.py` / `parse_doubles_issue.py` store canonical lowercase handles for new matches.
- **Read time** — `generate_singles_ranking.py`, `generate_doubles_ranking.py`, and `build_player_pages.py` normalize on load, so **existing** mixed-case data is merged too.

## Why

Latent silent failure: no error, just split stats / duplicate pages. (`Johnor12` is already stored with a capital J, so the exposure is live.)

## Tests

`tests/test_casing.py` (8 new): `normalize_player` behavior, parsers lowercasing handles, and aggregation deduping mixed casing to one player/team. Full suite: **55 passed**.

Verified end-to-end: two matches entered as `HunterJSB/Johnor12` and `hunterjsb/johnor12` aggregate to one `hunterjsb` / one `johnor12` with lowercase profile pages.

## Note

Display handles become lowercase (e.g. `Johnor12` → `johnor12`); links still work since GitHub is case-insensitive.