### PR TITLE
cli: auto-detect repo + gh token, validate handles, dry-run

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -11,17 +11,21 @@ go build -o tennis
 
 ## Configuration
 
-The CLI requires a GitHub token to interact with the repository. You can provide it in several ways:
+The CLI requires a GitHub token to interact with the repository. It is resolved in this order:
 
-1. Environment variable: `GITHUB_TOKEN=your_token_here`
-2. Environment variable: `GH_TOKEN=your_token_here`  
-3. Command line flag: `--token your_token_here`
+1. Command line flag: `--token your_token_here`
+2. Environment variable: `GITHUB_TOKEN=your_token_here`
+3. Environment variable: `GH_TOKEN=your_token_here`
+4. The `gh` CLI's stored token (via `gh auth token`), if `gh` is installed and authenticated
 
-The repository owner/name can be set via:
+So if you're already logged in with `gh auth login`, no token setup is needed.
 
-1. Environment variable: `GITHUB_REPOSITORY=owner/repo`
-2. Command line flags: `--owner owner --repo repo`
-3. Defaults to `stonehenge-collective/tennis`
+The repository owner/name is resolved in this order:
+
+1. Command line flags: `--owner owner --repo repo`
+2. Environment variable: `GITHUB_REPOSITORY=owner/repo`
+3. The `origin` remote of the current git checkout (https or ssh URLs)
+4. Defaults to `stonehenge-collective/tennis`
 
 ## Usage
 
@@ -94,6 +98,23 @@ export GITHUB_REPOSITORY=stonehenge-collective/tennis
 
 # Use specific date
 ./tennis match singles -p "@player_one,@player_two" -s "6-2,6-1" -d "2025-01-15"
+```
+
+### Flags for match commands
+
+Both `match singles` and `match doubles` support:
+
+- `--dry-run` — print the issue that would be created, without creating it (no token required)
+- `--no-validate` — skip the check that each player handle is a real GitHub user
+
+Before creating an issue, the CLI:
+
+- verifies every `@handle` resolves to a real GitHub user (skip with `--no-validate`). Note this only checks that the account exists, not that they're a registered league player.
+- (singles) checks the first-listed player actually won more sets, to catch swapped arguments
+
+```bash
+# Preview without creating anything
+./tennis match singles -p "@player_one,@player_two" -s "6-3,6-2" --dry-run
 ```
 
 ## Notes

--- a/cli/cmd_match.go
+++ b/cli/cmd_match.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -11,10 +12,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	dryRun     bool
+	noValidate bool
+)
+
 var matchCmd = &cobra.Command{
 	Use:   "match",
 	Short: "Create match issues",
 	Long:  "Create GitHub issues for recording tennis matches",
+}
+
+func printDryRun(title, body string, labels []string) {
+	fmt.Printf("[dry-run] would create issue in %s/%s\n", owner, repo)
+	fmt.Printf("Labels: %s\n", strings.Join(labels, ", "))
+	fmt.Printf("Title: %s\n\n%s\n", title, body)
 }
 
 var singlesMatchCmd = &cobra.Command{
@@ -62,6 +74,16 @@ If date is not provided, today's date will be used.`,
 		setsList, err := parseSets(sets)
 		if err != nil {
 			return fmt.Errorf("invalid sets format: %v", err)
+		}
+
+		// Warn if the first-listed player did not win more sets
+		if err := checkWinnerFirst(playerList[0], playerList[1], setsList); err != nil {
+			return err
+		}
+
+		// Verify the handles exist on GitHub (unless skipped)
+		if err := validateHandles(playerList); err != nil {
+			return err
 		}
 
 		// Create issue
@@ -125,6 +147,12 @@ If date is not provided, today's date will be used.`,
 			return fmt.Errorf("invalid sets format: %v", err)
 		}
 
+		// Verify the handles exist on GitHub (unless skipped)
+		allPlayers := append(append([]string{}, teamList[0]...), teamList[1]...)
+		if err := validateHandles(allPlayers); err != nil {
+			return err
+		}
+
 		// Create issue
 		return createDoublesIssue(teamList, setsList, date)
 	},
@@ -142,6 +170,10 @@ func isValidDate(date string) bool {
 }
 
 func parseSets(sets string) ([]string, error) {
+	if strings.TrimSpace(sets) == "" {
+		return nil, fmt.Errorf("at least one set is required")
+	}
+
 	setsList := strings.Split(sets, ",")
 	setRegex := regexp.MustCompile(`^\d+-\d+$`)
 
@@ -153,19 +185,56 @@ func parseSets(sets string) ([]string, error) {
 		setsList[i] = set
 	}
 
-	if len(setsList) == 0 {
-		return nil, fmt.Errorf("at least one set is required")
-	}
-
 	return setsList, nil
 }
 
-func createSinglesIssue(players []string, sets []string, date string) error {
+// checkWinnerFirst verifies the first-listed player won more sets than the
+// second, since the issue format requires the winner first. Ties are allowed
+// (e.g. an in-progress or split match) but a clear loser-first ordering is
+// rejected to catch swapped arguments before an issue is created.
+func checkWinnerFirst(player1, player2 string, sets []string) error {
+	var p1Wins, p2Wins int
+	for _, set := range sets {
+		parts := strings.SplitN(set, "-", 2)
+		g1, _ := strconv.Atoi(parts[0])
+		g2, _ := strconv.Atoi(parts[1])
+		switch {
+		case g1 > g2:
+			p1Wins++
+		case g2 > g1:
+			p2Wins++
+		}
+	}
+	if p2Wins > p1Wins {
+		return fmt.Errorf(
+			"%s won %d sets but is listed first as the winner (%s won %d) — list the winner first, or fix the scores",
+			player2, p2Wins, player1, p1Wins,
+		)
+	}
+	return nil
+}
+
+// validateHandles checks that each @handle resolves to a real GitHub user,
+// surfacing typos before an issue is created. Skipped when --no-validate is set.
+func validateHandles(handles []string) error {
+	if noValidate || dryRun {
+		return nil
+	}
 	ctx := context.Background()
 	client := getGitHubClient()
+	for _, h := range handles {
+		login := strings.TrimPrefix(strings.TrimSpace(h), "@")
+		if login == "" {
+			return fmt.Errorf("empty player handle")
+		}
+		if _, _, err := client.Users.Get(ctx, login); err != nil {
+			return fmt.Errorf("GitHub user '@%s' not found (use --no-validate to skip this check): %v", login, err)
+		}
+	}
+	return nil
+}
 
-	
-
+func createSinglesIssue(players []string, sets []string, date string) error {
 	title := fmt.Sprintf("Singles Match: %s vs %s (%s)", players[0], players[1], date)
 
 	body := fmt.Sprintf(`### Match date (YYYY-MM-DD)
@@ -183,6 +252,14 @@ func createSinglesIssue(players []string, sets []string, date string) error {
 		Labels: &[]string{"new-singles-match"},
 	}
 
+	if dryRun {
+		printDryRun(title, body, issueRequest.GetLabels())
+		return nil
+	}
+
+	ctx := context.Background()
+	client := getGitHubClient()
+
 	fmt.Printf("Creating singles match issue...\n")
 	fmt.Printf("Title: %s\n", title)
 
@@ -198,9 +275,6 @@ func createSinglesIssue(players []string, sets []string, date string) error {
 }
 
 func createDoublesIssue(teams [][]string, sets []string, date string) error {
-	ctx := context.Background()
-	client := getGitHubClient()
-
 	// Format teams for display
 	team1Str := fmt.Sprintf("%s, %s", teams[0][0], teams[0][1])
 	team2Str := fmt.Sprintf("%s, %s", teams[1][0], teams[1][1])
@@ -221,6 +295,14 @@ func createDoublesIssue(teams [][]string, sets []string, date string) error {
 		Body:   &body,
 		Labels: &[]string{"new-doubles-match"},
 	}
+
+	if dryRun {
+		printDryRun(title, body, issueRequest.GetLabels())
+		return nil
+	}
+
+	ctx := context.Background()
+	client := getGitHubClient()
 
 	fmt.Printf("Creating doubles match issue...\n")
 	fmt.Printf("Title: %s\n", title)
@@ -246,6 +328,10 @@ func init() {
 	doublesMatchCmd.Flags().StringP("teams", "t", "", "Teams separated by || : @player_one,@player_two||@player_three,@player_four")
 	doublesMatchCmd.Flags().StringP("sets", "s", "", "Sets separated by comma: 6-3,4-6,6-4")
 	doublesMatchCmd.Flags().StringP("date", "d", "", "Match date (YYYY-MM-DD), defaults to today")
+
+	// Shared flags for both match subcommands
+	matchCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Print the issue that would be created without creating it")
+	matchCmd.PersistentFlags().BoolVar(&noValidate, "no-validate", false, "Skip checking that player handles exist on GitHub")
 
 	matchCmd.AddCommand(singlesMatchCmd)
 	matchCmd.AddCommand(doublesMatchCmd)

--- a/cli/main.go
+++ b/cli/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/google/go-github/v67/github"
 	"github.com/spf13/cobra"
@@ -29,14 +31,19 @@ var rootCmd = &cobra.Command{
 			return nil
 		}
 
-		// Get token from environment if not provided
+		// Get token from environment if not provided. A dry run never
+		// contacts GitHub, so a token isn't required for it.
 		if token == "" {
 			token = os.Getenv("GITHUB_TOKEN")
 			if token == "" {
 				token = os.Getenv("GH_TOKEN")
 			}
+			// Fall back to the gh CLI's stored token if available
 			if token == "" {
-				return fmt.Errorf("GitHub token required. Set GITHUB_TOKEN environment variable or use --token flag")
+				token = ghAuthToken()
+			}
+			if token == "" && !dryRun {
+				return fmt.Errorf("GitHub token required. Set GITHUB_TOKEN, run `gh auth login`, or use --token flag")
 			}
 		}
 
@@ -52,7 +59,20 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		// Default fallback
+		// Fall back to the current checkout's git remote so the CLI
+		// targets whatever repo you're working in without flags.
+		if owner == "" || repo == "" {
+			if o, r, ok := repoFromGitRemote(); ok {
+				if owner == "" {
+					owner = o
+				}
+				if repo == "" {
+					repo = r
+				}
+			}
+		}
+
+		// Final fallback
 		if owner == "" {
 			owner = "stonehenge-collective"
 		}
@@ -62,6 +82,51 @@ var rootCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+// ghAuthToken returns the token stored by the `gh` CLI, or "" if gh is
+// unavailable or not authenticated.
+func ghAuthToken() string {
+	path, err := exec.LookPath("gh")
+	if err != nil {
+		return ""
+	}
+	out, err := exec.Command(path, "auth", "token").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// repoFromGitRemote parses owner/repo from the origin remote of the current
+// git checkout. Handles both https and ssh remote URLs.
+func repoFromGitRemote() (owner, repo string, ok bool) {
+	path, err := exec.LookPath("git")
+	if err != nil {
+		return "", "", false
+	}
+	out, err := exec.Command(path, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return "", "", false
+	}
+	url := strings.TrimSpace(string(out))
+	url = strings.TrimSuffix(url, ".git")
+
+	// git@github.com:owner/repo  ->  owner/repo
+	if i := strings.Index(url, ":"); strings.HasPrefix(url, "git@") && i != -1 {
+		url = url[i+1:]
+	} else if i := strings.Index(url, "github.com/"); i != -1 {
+		// https://github.com/owner/repo
+		url = url[i+len("github.com/"):]
+	} else {
+		return "", "", false
+	}
+
+	parts := strings.Split(url, "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
 }
 
 func splitRepoString(repoString string) []string {


### PR DESCRIPTION
Quality-of-life improvements to the `tennis` CLI, found while recording matches.

## Changes
- **Repo auto-detect** — resolves `owner/repo` from the current checkout's `origin` git remote (https + ssh) when not passed via flags / `GITHUB_REPOSITORY`. Falls back to `stonehenge-collective/tennis`.
- **`gh` token fallback** — if no `--token`/`GITHUB_TOKEN`/`GH_TOKEN`, uses `gh auth token`. No token setup needed when logged in via `gh`.
- **Handle validation** — verifies each `@handle` is a real GitHub user before creating an issue; typos fail fast and create nothing. `--no-validate` to skip. (Checks existence, not league membership.)
- **Winner-first guard** — singles rejects loser-first ordering (ties allowed for split sets) to catch swapped args.
- **`--dry-run`** — prints the issue that would be created without creating it (no token required).
- **Cleanup** — removed unreachable `len==0` check in `parseSets`, stray whitespace.

README updated for the new token/repo resolution order and flags.

## Testing
- dry-run with no token, repo auto-detected from git remote
- winner-first guard rejects `3-6,2-6`; allows split `6-3,3-6`
- `gh` token fallback with no env vars
- nonexistent handle rejected at validation (no issue created); `--no-validate` bypasses
- `go build`, `go vet`, `gofmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)